### PR TITLE
Fix README broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gocountry
-This is a [Go](golang.org) wrapper library around the API provided by [Restcountries](restcountries.eu).
+This is a [Go](golang.org) wrapper library around the API provided by [Restcountries](https://restcountries.eu).
 
 ## Installation
 Just go with


### PR DESCRIPTION
When navigating from Github, the Restcountries link redirects to https://github.com/alediaferia/gocountries/blob/master/restcountries.eu instead of https://restcountries.eu
